### PR TITLE
Add CI with GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+      - run: npm ci
+      - run: npm run build


### PR DESCRIPTION
Adapted from:
https://github.com/connorads/lockbot/blob/master/.github/workflows/build.yml

Example build log here:
https://github.com/connorads/lockbot/runs/1798546239

Because I've forked your repo you might have to faff around to get it to run in this PR:
https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/